### PR TITLE
Change preference detection method

### DIFF
--- a/scripts/appusage
+++ b/scripts/appusage
@@ -9,7 +9,7 @@ fi
 # Munki database check
 CWD=$(dirname $0)
 CACHEDIR="$CWD/cache/"
-MANAGEDINSTALLDIR=$(/usr/bin/python -c "from Foundation import CFPreferencesCopyAppValue; print CFPreferencesCopyAppValue('ManagedInstallDir', 'ManagedInstalls')")
+MANAGEDINSTALLDIR=$(osascript -l JavaScript -e "ObjC.import('Foundation'); ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('ManagedInstalls').objectForKey('ManagedInstallDir'))")
 
 if [[ -f "${MANAGEDINSTALLDIR}"/application_usage.sqlite ]]; then
 


### PR DESCRIPTION
System Python is removed as of macOS 12.3 so pathing to /usr/bin/python is no longer reliable.

This change alters the method for detecting the ManagedInstallDir key of ManagedInstalls but still uses the NSPreferences model so wherever the preference is set the highest priority location (Managed Preferences, OS Library/Preferences, root Library/Preferences, User Library/Preferences, etc.) will return the value.